### PR TITLE
fix(DetectionControllerIT): data precision conflict

### DIFF
--- a/src/main/java/app/bpartners/geojobs/repository/model/detection/Detection.java
+++ b/src/main/java/app/bpartners/geojobs/repository/model/detection/Detection.java
@@ -24,6 +24,7 @@ import jakarta.persistence.*;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -128,7 +129,7 @@ public class Detection implements Serializable {
 
   @PrePersist
   protected void onCreate() {
-    this.creationDatetime = now();
+    this.creationDatetime = now().truncatedTo(ChronoUnit.MICROS);
   }
 
   public void addStep(DetectionStep step) {

--- a/src/test/java/app/bpartners/geojobs/endpoint/rest/controller/DetectionControllerIT.java
+++ b/src/test/java/app/bpartners/geojobs/endpoint/rest/controller/DetectionControllerIT.java
@@ -289,8 +289,8 @@ class DetectionControllerIT extends FacadeIT {
             .geoJsonOutput(ZIP);
 
     // reordering the unordered geoJsonZone.properties because the test use a strict comparaison
-    orderGeoJsonProperties(expected);
-    orderGeoJsonProperties(actual.getFirst());
+    expected = orderGeoJsonProperties(expected);
+    actual = List.of(orderGeoJsonProperties(actual.getFirst()));
 
     assertNotNull(detection.getCreationDatetime());
     assertEquals(List.of(expected), actual);
@@ -314,19 +314,24 @@ class DetectionControllerIT extends FacadeIT {
             .geoJsonOutput(GEO_JSON);
 
     // reordering the unordered geoJsonZone.properties because the test use a strict comparaison
-    orderGeoJsonProperties(expected);
-    orderGeoJsonProperties(actual.getFirst());
+    expected = orderGeoJsonProperties(expected);
+    actual = List.of(orderGeoJsonProperties(actual.getFirst()));
 
     assertNotNull(detection.getCreationDatetime());
     assertEquals(List.of(expected), actual);
   }
 
-  private static void orderGeoJsonProperties(
+  private static app.bpartners.geojobs.endpoint.rest.model.Detection orderGeoJsonProperties(
       app.bpartners.geojobs.endpoint.rest.model.Detection detection) {
-    detection.geoJsonZone(
-        detection.getGeoJsonZone().stream()
-            .map(f -> f.properties(new TreeMap<>(f.getProperties())))
-            .toList());
+    return new app.bpartners.geojobs.endpoint.rest.model.Detection()
+        .id(detection.getId())
+        .creationDatetime(detection.getCreationDatetime())
+        .step(detection.getStep())
+        .geoJsonOutput(detection.getGeoJsonOutput())
+        .geoJsonZone(
+            detection.getGeoJsonZone().stream()
+                .map(f -> f.properties(new TreeMap<>(f.getProperties())))
+                .toList());
   }
 
   @Test

--- a/src/test/java/app/bpartners/geojobs/endpoint/rest/controller/DetectionControllerIT.java
+++ b/src/test/java/app/bpartners/geojobs/endpoint/rest/controller/DetectionControllerIT.java
@@ -62,6 +62,7 @@ import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.TreeMap;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -286,6 +287,11 @@ class DetectionControllerIT extends FacadeIT {
                 detectionStepStatisticMapper.toRestDetectionStepStatus(
                     statistic, DetectionStepName.MACHINE_DETECTION))
             .geoJsonOutput(ZIP);
+
+    // reordering the unordered geoJsonZone.properties because the test use a strict comparaison
+    orderGeoJsonProperties(expected);
+    orderGeoJsonProperties(actual.getFirst());
+
     assertNotNull(detection.getCreationDatetime());
     assertEquals(List.of(expected), actual);
   }
@@ -306,8 +312,21 @@ class DetectionControllerIT extends FacadeIT {
             .geoJsonZone(featureCreator.defaultFeatures())
             .step(actual.getFirst().getStep())
             .geoJsonOutput(GEO_JSON);
+
+    // reordering the unordered geoJsonZone.properties because the test use a strict comparaison
+    orderGeoJsonProperties(expected);
+    orderGeoJsonProperties(actual.getFirst());
+
     assertNotNull(detection.getCreationDatetime());
     assertEquals(List.of(expected), actual);
+  }
+
+  private static void orderGeoJsonProperties(
+      app.bpartners.geojobs.endpoint.rest.model.Detection detection) {
+    detection.geoJsonZone(
+        detection.getGeoJsonZone().stream()
+            .map(f -> f.properties(new TreeMap<>(f.getProperties())))
+            .toList());
   }
 
   @Test


### PR DESCRIPTION
_Synced precision_ of Detection's creation date between Java and JPA;
and _ignore order of Detection.geoJsonZone.properties elements_ in Test DetectionControllerIT.