### PR TITLE
fix: get distinct community authorization by api key

### DIFF
--- a/src/main/java/app/bpartners/geojobs/repository/CommunityAuthorizationRepository.java
+++ b/src/main/java/app/bpartners/geojobs/repository/CommunityAuthorizationRepository.java
@@ -13,7 +13,7 @@ public interface CommunityAuthorizationRepository
 
   @Query(
       """
-      SELECT c FROM community_authorization c
+      SELECT DISTINCT c FROM community_authorization c
       LEFT JOIN c.apiKeys k
       WHERE c.apiKey = :key OR c.dashboardApiKey = :key OR k.keyValue = :key
       """)
@@ -23,7 +23,7 @@ public interface CommunityAuthorizationRepository
 
   @Query(
       """
-      SELECT c FROM community_authorization c
+      SELECT DISTINCT c FROM community_authorization c
       LEFT JOIN c.apiKeys k
       WHERE c.apiKey = :key OR c.dashboardApiKey = :key OR k.keyValue = :key
       """)

--- a/src/test/java/app/bpartners/geojobs/repository/CommunityAuthorizationRepositoryIT.java
+++ b/src/test/java/app/bpartners/geojobs/repository/CommunityAuthorizationRepositoryIT.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class CommunityAuthorizationRepositoryTest extends FacadeIT {
+class CommunityAuthorizationRepositoryIT extends FacadeIT {
 
   @Autowired CommunityAuthorizationRepository subject;
 


### PR DESCRIPTION
This commit fixes a JPA error that occurs when multiple API keys are owned by a community authorization.